### PR TITLE
Add combined LinkedIn and Instagram social feed

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -11,6 +11,28 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "framerusercontent.com",
       },
+      // Instagram CDN domains
+      {
+        protocol: "https",
+        hostname: "*.cdninstagram.com",
+      },
+      {
+        protocol: "https",
+        hostname: "scontent.cdninstagram.com",
+      },
+      {
+        protocol: "https",
+        hostname: "scontent-*.cdninstagram.com",
+      },
+      // LinkedIn CDN domains
+      {
+        protocol: "https",
+        hostname: "media.licdn.com",
+      },
+      {
+        protocol: "https",
+        hostname: "*.licdn.com",
+      },
     ],
   },
   logging: {

--- a/web/src/app/(site)/page.tsx
+++ b/web/src/app/(site)/page.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
 import Image from "next/image";
 import type { Metadata } from "next";
-import { InstagramFeed } from "@/components/sections/InstagramFeed";
+import { SocialFeed } from "@/components/sections/SocialFeed";
 import { CommunityPhotosGrid } from "@/components/sections/CommunityPhotosGrid";
 import { sanityFetch } from "@/sanity/lib/live";
-import { INSTAGRAM_POSTS_QUERY, COMMUNITY_PHOTOS_QUERY } from "@/sanity/lib/queries";
+import { COMMUNITY_PHOTOS_QUERY } from "@/sanity/lib/queries";
 
 export const metadata: Metadata = {
   title: "UXHI - A UX design community for people in Hawaiʻi",
@@ -61,10 +61,7 @@ function BookOpenIcon({ className = "w-6 h-6" }: { className?: string }) {
 
 export default async function HomePage() {
   // Fetch data from Sanity
-  const [{ data: instagramPosts }, { data: communityPhotos }] = await Promise.all([
-    sanityFetch({ query: INSTAGRAM_POSTS_QUERY }),
-    sanityFetch({ query: COMMUNITY_PHOTOS_QUERY }),
-  ]);
+  const { data: communityPhotos } = await sanityFetch({ query: COMMUNITY_PHOTOS_QUERY });
 
   return (
     <>
@@ -357,7 +354,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      {/* Instagram Feed Section */}
+      {/* Social Feed Section */}
       <section className="py-20 px-6">
         <div className="max-w-[1300px] mx-auto">
           <div className="text-center mb-12">
@@ -367,7 +364,7 @@ export default async function HomePage() {
             <p className="text-gray-600 text-lg">Stay connected with our latest events and community updates</p>
           </div>
 
-          <InstagramFeed posts={instagramPosts || []} />
+          <SocialFeed />
         </div>
       </section>
 

--- a/web/src/app/api/linkedin/route.ts
+++ b/web/src/app/api/linkedin/route.ts
@@ -1,0 +1,122 @@
+import { NextResponse } from "next/server";
+import type { SocialPost } from "@/lib/social-feed";
+
+/**
+ * LinkedIn API endpoint to fetch organization posts
+ *
+ * Required environment variables:
+ * - LINKEDIN_ACCESS_TOKEN: OAuth access token with r_organization_social scope
+ * - LINKEDIN_ORGANIZATION_ID: The organization/company page ID
+ *
+ * LinkedIn API docs: https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api
+ */
+
+const LINKEDIN_API_BASE = "https://api.linkedin.com/rest";
+
+interface LinkedInPost {
+  id: string;
+  author: string;
+  commentary?: string;
+  publishedAt: string;
+  content?: {
+    media?: {
+      id: string;
+    };
+    multiImage?: {
+      images: Array<{ id: string }>;
+    };
+  };
+}
+
+interface LinkedInMediaResponse {
+  downloadUrl?: string;
+}
+
+export async function GET() {
+  const accessToken = process.env.LINKEDIN_ACCESS_TOKEN;
+  const organizationId = process.env.LINKEDIN_ORGANIZATION_ID;
+
+  // If not configured, return empty array gracefully
+  if (!accessToken || !organizationId) {
+    return NextResponse.json({
+      posts: [],
+      message: "LinkedIn API not configured.",
+    });
+  }
+
+  try {
+    // Fetch posts from the organization
+    const postsResponse = await fetch(
+      `${LINKEDIN_API_BASE}/posts?author=urn%3Ali%3Aorganization%3A${organizationId}&q=author&count=12`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "LinkedIn-Version": "202401",
+          "X-Restli-Protocol-Version": "2.0.0",
+        },
+        next: { revalidate: 3600 }, // Cache for 1 hour
+      }
+    );
+
+    if (!postsResponse.ok) {
+      const errorText = await postsResponse.text();
+      console.error("LinkedIn API response:", postsResponse.status, errorText);
+      throw new Error(`LinkedIn API error: ${postsResponse.status}`);
+    }
+
+    const postsData = await postsResponse.json();
+    const elements: LinkedInPost[] = postsData.elements || [];
+
+    // Filter to posts with images and transform to SocialPost format
+    const posts: SocialPost[] = [];
+
+    for (const post of elements) {
+      // Only include posts with media
+      const mediaId = post.content?.media?.id || post.content?.multiImage?.images?.[0]?.id;
+      if (!mediaId) continue;
+
+      // Fetch the media download URL
+      try {
+        const mediaResponse = await fetch(
+          `${LINKEDIN_API_BASE}/images/${encodeURIComponent(mediaId)}`,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              "LinkedIn-Version": "202401",
+              "X-Restli-Protocol-Version": "2.0.0",
+            },
+            next: { revalidate: 3600 },
+          }
+        );
+
+        if (!mediaResponse.ok) continue;
+
+        const mediaData: LinkedInMediaResponse = await mediaResponse.json();
+        if (!mediaData.downloadUrl) continue;
+
+        posts.push({
+          id: post.id,
+          platform: "linkedin",
+          imageUrl: mediaData.downloadUrl,
+          permalink: `https://www.linkedin.com/feed/update/${post.id}`,
+          caption: post.commentary,
+          timestamp: post.publishedAt,
+        });
+
+        // Limit to 8 posts max
+        if (posts.length >= 8) break;
+      } catch {
+        // Skip posts where media fetch fails
+        continue;
+      }
+    }
+
+    return NextResponse.json({ posts });
+  } catch (error) {
+    console.error("LinkedIn API error:", error);
+    return NextResponse.json(
+      { posts: [], error: "Failed to fetch LinkedIn posts" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/app/api/linkedin/route.ts
+++ b/web/src/app/api/linkedin/route.ts
@@ -1,17 +1,31 @@
 import { NextResponse } from "next/server";
+import { client, writeClient } from "@/sanity/lib/client";
 import type { SocialPost } from "@/lib/social-feed";
 
 /**
- * LinkedIn API endpoint to fetch organization posts
+ * LinkedIn API endpoint to fetch organization posts with auto-refresh
  *
- * Required environment variables:
- * - LINKEDIN_ACCESS_TOKEN: OAuth access token with r_organization_social scope
- * - LINKEDIN_ORGANIZATION_ID: The organization/company page ID
+ * Token priority:
+ * 1. Sanity apiSettings document (auto-refreshed)
+ * 2. Environment variables (initial setup)
  *
- * LinkedIn API docs: https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api
+ * Required environment variables for initial setup:
+ * - LINKEDIN_ACCESS_TOKEN
+ * - LINKEDIN_REFRESH_TOKEN
+ * - LINKEDIN_CLIENT_ID
+ * - LINKEDIN_CLIENT_SECRET
+ * - LINKEDIN_ORGANIZATION_ID
  */
 
 const LINKEDIN_API_BASE = "https://api.linkedin.com/rest";
+const LINKEDIN_OAUTH_URL = "https://www.linkedin.com/oauth/v2/accessToken";
+const API_SETTINGS_ID = "apiSettings";
+
+interface LinkedInTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt?: string;
+}
 
 interface LinkedInPost {
   id: string;
@@ -32,91 +46,253 @@ interface LinkedInMediaResponse {
   downloadUrl?: string;
 }
 
-export async function GET() {
+/**
+ * Get LinkedIn tokens from Sanity or fall back to env vars
+ */
+async function getTokens(): Promise<LinkedInTokens | null> {
+  // Try Sanity first
+  try {
+    const settings = await client.fetch(
+      `*[_type == "apiSettings"][0]{ linkedin }`
+    );
+
+    if (settings?.linkedin?.accessToken && settings?.linkedin?.refreshToken) {
+      return {
+        accessToken: settings.linkedin.accessToken,
+        refreshToken: settings.linkedin.refreshToken,
+        expiresAt: settings.linkedin.expiresAt,
+      };
+    }
+  } catch (error) {
+    console.error("Error fetching tokens from Sanity:", error);
+  }
+
+  // Fall back to env vars
   const accessToken = process.env.LINKEDIN_ACCESS_TOKEN;
+  const refreshToken = process.env.LINKEDIN_REFRESH_TOKEN;
+
+  if (accessToken && refreshToken) {
+    return { accessToken, refreshToken };
+  }
+
+  return null;
+}
+
+/**
+ * Refresh the access token using the refresh token
+ */
+async function refreshAccessToken(
+  refreshToken: string
+): Promise<LinkedInTokens | null> {
+  const clientId = process.env.LINKEDIN_CLIENT_ID;
+  const clientSecret = process.env.LINKEDIN_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    console.error("LinkedIn client credentials not configured");
+    return null;
+  }
+
+  try {
+    const response = await fetch(LINKEDIN_OAUTH_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("Token refresh failed:", response.status, errorText);
+      return null;
+    }
+
+    const data = await response.json();
+
+    // Calculate expiration time (LinkedIn tokens expire in ~60 days)
+    const expiresAt = new Date(
+      Date.now() + (data.expires_in || 5184000) * 1000
+    ).toISOString();
+
+    return {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token || refreshToken, // Use new refresh token if provided
+      expiresAt,
+    };
+  } catch (error) {
+    console.error("Error refreshing token:", error);
+    return null;
+  }
+}
+
+/**
+ * Store tokens in Sanity for persistence
+ */
+async function storeTokens(tokens: LinkedInTokens): Promise<void> {
+  if (!writeClient.config().token) {
+    console.warn("Sanity write token not configured, cannot persist tokens");
+    return;
+  }
+
+  try {
+    // Check if apiSettings document exists
+    const existing = await client.fetch(
+      `*[_type == "apiSettings"][0]{ _id }`
+    );
+
+    if (existing) {
+      // Update existing document
+      await writeClient
+        .patch(existing._id)
+        .set({
+          "linkedin.accessToken": tokens.accessToken,
+          "linkedin.refreshToken": tokens.refreshToken,
+          "linkedin.expiresAt": tokens.expiresAt,
+        })
+        .commit();
+    } else {
+      // Create new document
+      await writeClient.create({
+        _type: "apiSettings",
+        _id: API_SETTINGS_ID,
+        title: "API Settings",
+        linkedin: {
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+          expiresAt: tokens.expiresAt,
+        },
+      });
+    }
+
+    console.log("LinkedIn tokens stored in Sanity");
+  } catch (error) {
+    console.error("Error storing tokens in Sanity:", error);
+  }
+}
+
+/**
+ * Fetch posts from LinkedIn API
+ */
+async function fetchLinkedInPosts(
+  accessToken: string,
+  organizationId: string
+): Promise<{ posts: SocialPost[]; status: number }> {
+  const postsResponse = await fetch(
+    `${LINKEDIN_API_BASE}/posts?author=urn%3Ali%3Aorganization%3A${organizationId}&q=author&count=12`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "LinkedIn-Version": "202401",
+        "X-Restli-Protocol-Version": "2.0.0",
+      },
+      cache: "no-store", // Don't cache since we may need to retry with new token
+    }
+  );
+
+  if (!postsResponse.ok) {
+    return { posts: [], status: postsResponse.status };
+  }
+
+  const postsData = await postsResponse.json();
+  const elements: LinkedInPost[] = postsData.elements || [];
+
+  // Filter to posts with images and transform to SocialPost format
+  const posts: SocialPost[] = [];
+
+  for (const post of elements) {
+    const mediaId =
+      post.content?.media?.id || post.content?.multiImage?.images?.[0]?.id;
+    if (!mediaId) continue;
+
+    try {
+      const mediaResponse = await fetch(
+        `${LINKEDIN_API_BASE}/images/${encodeURIComponent(mediaId)}`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "LinkedIn-Version": "202401",
+            "X-Restli-Protocol-Version": "2.0.0",
+          },
+        }
+      );
+
+      if (!mediaResponse.ok) continue;
+
+      const mediaData: LinkedInMediaResponse = await mediaResponse.json();
+      if (!mediaData.downloadUrl) continue;
+
+      posts.push({
+        id: post.id,
+        platform: "linkedin",
+        imageUrl: mediaData.downloadUrl,
+        permalink: `https://www.linkedin.com/feed/update/${post.id}`,
+        caption: post.commentary,
+        timestamp: post.publishedAt,
+      });
+
+      if (posts.length >= 8) break;
+    } catch {
+      continue;
+    }
+  }
+
+  return { posts, status: 200 };
+}
+
+export async function GET() {
   const organizationId = process.env.LINKEDIN_ORGANIZATION_ID;
 
-  // If not configured, return empty array gracefully
-  if (!accessToken || !organizationId) {
+  if (!organizationId) {
+    return NextResponse.json({
+      posts: [],
+      message: "LinkedIn Organization ID not configured.",
+    });
+  }
+
+  // Get tokens
+  let tokens = await getTokens();
+
+  if (!tokens) {
     return NextResponse.json({
       posts: [],
       message: "LinkedIn API not configured.",
     });
   }
 
-  try {
-    // Fetch posts from the organization
-    const postsResponse = await fetch(
-      `${LINKEDIN_API_BASE}/posts?author=urn%3Ali%3Aorganization%3A${organizationId}&q=author&count=12`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          "LinkedIn-Version": "202401",
-          "X-Restli-Protocol-Version": "2.0.0",
-        },
-        next: { revalidate: 3600 }, // Cache for 1 hour
-      }
-    );
+  // Try to fetch posts
+  let result = await fetchLinkedInPosts(tokens.accessToken, organizationId);
 
-    if (!postsResponse.ok) {
-      const errorText = await postsResponse.text();
-      console.error("LinkedIn API response:", postsResponse.status, errorText);
-      throw new Error(`LinkedIn API error: ${postsResponse.status}`);
+  // If unauthorized (401), try refreshing the token
+  if (result.status === 401) {
+    console.log("LinkedIn token expired, attempting refresh...");
+
+    const newTokens = await refreshAccessToken(tokens.refreshToken);
+
+    if (newTokens) {
+      // Store the new tokens
+      await storeTokens(newTokens);
+
+      // Retry the request
+      result = await fetchLinkedInPosts(newTokens.accessToken, organizationId);
+    } else {
+      return NextResponse.json({
+        posts: [],
+        error: "Token refresh failed. Please re-authenticate.",
+      });
     }
+  }
 
-    const postsData = await postsResponse.json();
-    const elements: LinkedInPost[] = postsData.elements || [];
-
-    // Filter to posts with images and transform to SocialPost format
-    const posts: SocialPost[] = [];
-
-    for (const post of elements) {
-      // Only include posts with media
-      const mediaId = post.content?.media?.id || post.content?.multiImage?.images?.[0]?.id;
-      if (!mediaId) continue;
-
-      // Fetch the media download URL
-      try {
-        const mediaResponse = await fetch(
-          `${LINKEDIN_API_BASE}/images/${encodeURIComponent(mediaId)}`,
-          {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-              "LinkedIn-Version": "202401",
-              "X-Restli-Protocol-Version": "2.0.0",
-            },
-            next: { revalidate: 3600 },
-          }
-        );
-
-        if (!mediaResponse.ok) continue;
-
-        const mediaData: LinkedInMediaResponse = await mediaResponse.json();
-        if (!mediaData.downloadUrl) continue;
-
-        posts.push({
-          id: post.id,
-          platform: "linkedin",
-          imageUrl: mediaData.downloadUrl,
-          permalink: `https://www.linkedin.com/feed/update/${post.id}`,
-          caption: post.commentary,
-          timestamp: post.publishedAt,
-        });
-
-        // Limit to 8 posts max
-        if (posts.length >= 8) break;
-      } catch {
-        // Skip posts where media fetch fails
-        continue;
-      }
-    }
-
-    return NextResponse.json({ posts });
-  } catch (error) {
-    console.error("LinkedIn API error:", error);
+  if (result.status !== 200) {
     return NextResponse.json(
-      { posts: [], error: "Failed to fetch LinkedIn posts" },
+      { posts: [], error: `LinkedIn API error: ${result.status}` },
       { status: 500 }
     );
   }
+
+  return NextResponse.json({ posts: result.posts });
 }

--- a/web/src/app/api/social-feed/route.ts
+++ b/web/src/app/api/social-feed/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import type { SocialPost } from "@/lib/social-feed";
+import { mergeSocialPosts } from "@/lib/social-feed";
+
+/**
+ * Combined social feed endpoint
+ * Fetches posts from Instagram and LinkedIn, merges them with Instagram priority on same-day conflicts
+ */
+
+interface InstagramApiPost {
+  id: string;
+  media_url: string;
+  permalink: string;
+  caption?: string;
+  media_type: string;
+  timestamp: string;
+}
+
+export async function GET(request: Request) {
+  const baseUrl = new URL(request.url).origin;
+
+  // Fetch both APIs in parallel
+  const [instagramResult, linkedInResult] = await Promise.allSettled([
+    fetch(`${baseUrl}/api/instagram`, { next: { revalidate: 3600 } }),
+    fetch(`${baseUrl}/api/linkedin`, { next: { revalidate: 3600 } }),
+  ]);
+
+  // Parse Instagram response
+  let instagramPosts: SocialPost[] = [];
+  if (instagramResult.status === "fulfilled" && instagramResult.value.ok) {
+    try {
+      const data = await instagramResult.value.json();
+      // Transform Instagram API response to SocialPost format
+      instagramPosts = (data.posts || []).map((post: InstagramApiPost) => ({
+        id: post.id,
+        platform: "instagram" as const,
+        imageUrl: post.media_url,
+        permalink: post.permalink,
+        caption: post.caption,
+        timestamp: post.timestamp,
+      }));
+    } catch (error) {
+      console.error("Error parsing Instagram response:", error);
+    }
+  }
+
+  // Parse LinkedIn response
+  let linkedInPosts: SocialPost[] = [];
+  if (linkedInResult.status === "fulfilled" && linkedInResult.value.ok) {
+    try {
+      const data = await linkedInResult.value.json();
+      // LinkedIn API already returns SocialPost format
+      linkedInPosts = data.posts || [];
+    } catch (error) {
+      console.error("Error parsing LinkedIn response:", error);
+    }
+  }
+
+  // Merge posts with Instagram priority on same-day conflicts
+  const mergedPosts = mergeSocialPosts(instagramPosts, linkedInPosts, 8);
+
+  return NextResponse.json({
+    posts: mergedPosts,
+    sources: {
+      instagram: instagramPosts.length,
+      linkedin: linkedInPosts.length,
+    },
+  });
+}

--- a/web/src/components/sections/SocialFeed.tsx
+++ b/web/src/components/sections/SocialFeed.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import type { SocialPost } from "@/lib/social-feed";
+
+// Instagram icon component
+function InstagramIcon({ className = "w-8 h-8" }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z" />
+    </svg>
+  );
+}
+
+// LinkedIn icon component
+function LinkedInIcon({ className = "w-8 h-8" }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  );
+}
+
+// Fallback posts when APIs are not configured
+const fallbackPosts: SocialPost[] = [
+  { id: "1", platform: "instagram", imageUrl: "/images/instagram/post-1.jpg", permalink: "https://www.instagram.com/uxhicommunity/", timestamp: new Date().toISOString() },
+  { id: "2", platform: "instagram", imageUrl: "/images/instagram/post-2.jpg", permalink: "https://www.instagram.com/uxhicommunity/", timestamp: new Date().toISOString() },
+  { id: "3", platform: "instagram", imageUrl: "/images/instagram/post-3.jpg", permalink: "https://www.instagram.com/uxhicommunity/", timestamp: new Date().toISOString() },
+  { id: "4", platform: "instagram", imageUrl: "/images/instagram/post-4.jpg", permalink: "https://www.instagram.com/uxhicommunity/", timestamp: new Date().toISOString() },
+  { id: "5", platform: "instagram", imageUrl: "/images/instagram/post-5.jpg", permalink: "https://www.instagram.com/uxhicommunity/", timestamp: new Date().toISOString() },
+  { id: "6", platform: "instagram", imageUrl: "/images/instagram/post-6.jpg", permalink: "https://www.instagram.com/uxhicommunity/", timestamp: new Date().toISOString() },
+  { id: "7", platform: "instagram", imageUrl: "/images/instagram/post-7.jpg", permalink: "https://www.instagram.com/uxhicommunity/", timestamp: new Date().toISOString() },
+  { id: "8", platform: "instagram", imageUrl: "/images/instagram/post-8.jpg", permalink: "https://www.instagram.com/uxhicommunity/", timestamp: new Date().toISOString() },
+];
+
+function SocialPostCard({ post }: { post: SocialPost }) {
+  const Icon = post.platform === "instagram" ? InstagramIcon : LinkedInIcon;
+  const platformLabel =
+    post.platform === "instagram" ? "View on Instagram" : "View on LinkedIn";
+
+  return (
+    <a
+      href={post.permalink}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="rounded-[20px] overflow-hidden aspect-[4/5] relative group cursor-pointer bg-gray-100"
+    >
+      <Image
+        src={post.imageUrl}
+        alt={post.caption || `${post.platform} post`}
+        fill
+        className="object-cover transition-transform duration-300 group-hover:scale-105"
+      />
+      <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-col items-center justify-center gap-3">
+        <Icon className="w-10 h-10 text-white" />
+        <span className="text-white text-sm font-medium">{platformLabel}</span>
+      </div>
+    </a>
+  );
+}
+
+export function SocialFeed() {
+  const [posts, setPosts] = useState<SocialPost[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchPosts() {
+      try {
+        const response = await fetch("/api/social-feed");
+        if (!response.ok) {
+          throw new Error("Failed to fetch social posts");
+        }
+        const data = await response.json();
+        setPosts(data.posts || []);
+      } catch (error) {
+        console.error("Error fetching social feed:", error);
+        setPosts([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchPosts();
+  }, []);
+
+  // Loading skeleton
+  if (loading) {
+    return (
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[...Array(8)].map((_, i) => (
+          <div
+            key={i}
+            className="rounded-[20px] overflow-hidden aspect-[4/5] bg-gray-200 animate-pulse"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  // Use fetched posts or fallback
+  const displayPosts = posts.length > 0 ? posts : fallbackPosts;
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {displayPosts.map((post) => (
+        <SocialPostCard key={post.id} post={post} />
+      ))}
+    </div>
+  );
+}

--- a/web/src/lib/social-feed.ts
+++ b/web/src/lib/social-feed.ts
@@ -1,0 +1,43 @@
+/**
+ * Social feed types and utilities for combining Instagram and LinkedIn posts
+ */
+
+export interface SocialPost {
+  id: string;
+  platform: "instagram" | "linkedin";
+  imageUrl: string;
+  permalink: string;
+  caption?: string;
+  timestamp: string;
+}
+
+/**
+ * Merge Instagram and LinkedIn posts with the following rules:
+ * 1. If both platforms have posts on the same day, only show Instagram
+ * 2. Sort all posts by timestamp (newest first)
+ * 3. Return maximum of `limit` posts
+ */
+export function mergeSocialPosts(
+  instagramPosts: SocialPost[],
+  linkedInPosts: SocialPost[],
+  limit: number = 8
+): SocialPost[] {
+  // Create a set of dates that have Instagram posts
+  const instagramDates = new Set(
+    instagramPosts.map((post) => new Date(post.timestamp).toDateString())
+  );
+
+  // Filter LinkedIn posts to exclude those on days that have Instagram posts
+  const filteredLinkedIn = linkedInPosts.filter(
+    (post) => !instagramDates.has(new Date(post.timestamp).toDateString())
+  );
+
+  // Combine and sort by timestamp (newest first)
+  const combined = [...instagramPosts, ...filteredLinkedIn];
+  combined.sort(
+    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+
+  // Return limited results
+  return combined.slice(0, limit);
+}

--- a/web/src/sanity/env.ts
+++ b/web/src/sanity/env.ts
@@ -5,3 +5,6 @@ export const apiVersion = process.env.NEXT_PUBLIC_SANITY_API_VERSION || "2024-01
 
 // Used for server-side fetching
 export const token = process.env.SANITY_API_READ_TOKEN;
+
+// Used for mutations (storing refreshed tokens)
+export const writeToken = process.env.SANITY_API_WRITE_TOKEN;

--- a/web/src/sanity/lib/client.ts
+++ b/web/src/sanity/lib/client.ts
@@ -1,5 +1,5 @@
 import { createClient } from "next-sanity";
-import { projectId, dataset, apiVersion } from "../env";
+import { projectId, dataset, apiVersion, writeToken } from "../env";
 
 export const client = createClient({
   projectId,
@@ -10,4 +10,13 @@ export const client = createClient({
     enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === "preview",
     studioUrl: "/studio",
   },
+});
+
+// Client with write access for mutations (e.g., storing refreshed tokens)
+export const writeClient = createClient({
+  projectId,
+  dataset,
+  apiVersion,
+  useCdn: false,
+  token: writeToken,
 });

--- a/web/src/sanity/schemaTypes/documents/apiSettings.ts
+++ b/web/src/sanity/schemaTypes/documents/apiSettings.ts
@@ -1,0 +1,51 @@
+import { defineType, defineField } from "sanity";
+import { CogIcon } from "@sanity/icons";
+
+export const apiSettings = defineType({
+  name: "apiSettings",
+  title: "API Settings",
+  type: "document",
+  icon: CogIcon,
+  fields: [
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+      initialValue: "API Settings",
+      readOnly: true,
+    }),
+    defineField({
+      name: "linkedin",
+      title: "LinkedIn API",
+      type: "object",
+      fields: [
+        defineField({
+          name: "accessToken",
+          title: "Access Token",
+          type: "string",
+          description: "LinkedIn OAuth access token (auto-refreshed)",
+        }),
+        defineField({
+          name: "refreshToken",
+          title: "Refresh Token",
+          type: "string",
+          description: "LinkedIn OAuth refresh token",
+        }),
+        defineField({
+          name: "expiresAt",
+          title: "Expires At",
+          type: "datetime",
+          description: "When the access token expires",
+        }),
+      ],
+    }),
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: "API Settings",
+        subtitle: "LinkedIn and other API credentials",
+      };
+    },
+  },
+});

--- a/web/src/sanity/schemaTypes/index.ts
+++ b/web/src/sanity/schemaTypes/index.ts
@@ -6,6 +6,7 @@ import { member } from "./documents/member";
 import { faq } from "./documents/faq";
 import { instagramPost } from "./documents/instagramPost";
 import { communityPhoto } from "./documents/communityPhoto";
+import { apiSettings } from "./documents/apiSettings";
 
 export const schemaTypes = [
   // Documents
@@ -16,4 +17,5 @@ export const schemaTypes = [
   faq,
   instagramPost,
   communityPhoto,
+  apiSettings,
 ];


### PR DESCRIPTION
## Summary
- Add combined social feed that displays posts from both LinkedIn and Instagram
- Instagram takes priority when both platforms have posts on the same day
- Maximum 8 posts displayed, sorted by most recent
- Platform-aware hover overlays show correct icon (Instagram/LinkedIn)
- Auto-refresh for LinkedIn tokens stored in Sanity

## Changes
- **New files:**
  - `web/src/lib/social-feed.ts` - Types and merge utility
  - `web/src/app/api/linkedin/route.ts` - LinkedIn API endpoint with auto-refresh
  - `web/src/app/api/social-feed/route.ts` - Combined feed endpoint
  - `web/src/components/sections/SocialFeed.tsx` - Client component
  - `web/src/sanity/schemaTypes/documents/apiSettings.ts` - Schema for storing tokens

- **Modified files:**
  - `web/next.config.ts` - Added Instagram/LinkedIn CDN domains
  - `web/src/app/(site)/page.tsx` - Replaced InstagramFeed with SocialFeed
  - `web/src/sanity/lib/client.ts` - Added writeClient for mutations
  - `web/src/sanity/env.ts` - Added writeToken export

---

## Setup Instructions

### 1. Create LinkedIn Developer App
1. Go to https://www.linkedin.com/developers/apps
2. Click **Create app**
3. Fill in app details and associate with your company page
4. Request access to **Community Management API** product

### 2. Get Organization ID
1. Go to your LinkedIn Company Page
2. Click **Admin tools** → **Page info**
3. The URL will be like: `linkedin.com/company/12345678/admin/`
4. Copy the number (`12345678`) - this is your Organization ID

### 3. Complete OAuth Flow
1. In your LinkedIn app, go to **Auth** tab
2. Add redirect URL: `https://localhost:3000/callback`
3. Visit this URL (replace YOUR_CLIENT_ID):
   ```
   https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id=YOUR_CLIENT_ID&redirect_uri=https://localhost:3000/callback&scope=r_organization_social
   ```
4. After authorizing, you'll be redirected with a `code` parameter
5. Exchange the code for tokens:
   ```bash
   curl -X POST https://www.linkedin.com/oauth/v2/accessToken \
     -d "grant_type=authorization_code" \
     -d "code=YOUR_CODE" \
     -d "client_id=YOUR_CLIENT_ID" \
     -d "client_secret=YOUR_CLIENT_SECRET" \
     -d "redirect_uri=https://localhost:3000/callback"
   ```
6. Save both `access_token` and `refresh_token` from the response

### 4. Create Sanity Write Token
1. Go to https://www.sanity.io/manage/project/evh83z0t
2. Navigate to **API** → **Tokens**
3. Click **Add API token**
4. Name it "LinkedIn Token Storage" and select **Editor** permissions
5. Copy the token

### 5. Set Environment Variables in Vercel
Add these environment variables:

| Variable | Description |
|----------|-------------|
| `LINKEDIN_ACCESS_TOKEN` | OAuth access token from step 3 |
| `LINKEDIN_REFRESH_TOKEN` | OAuth refresh token from step 3 |
| `LINKEDIN_CLIENT_ID` | From LinkedIn app settings |
| `LINKEDIN_CLIENT_SECRET` | From LinkedIn app settings |
| `LINKEDIN_ORGANIZATION_ID` | Company page ID from step 2 |
| `SANITY_API_WRITE_TOKEN` | Sanity token from step 4 |

### 6. Deploy and Test
1. Deploy to Vercel
2. Visit `/api/linkedin` to test the endpoint
3. The social feed on the homepage should now show LinkedIn posts

---

## How Auto-Refresh Works
- Tokens are initially read from environment variables
- When the access token expires (401 response), it's automatically refreshed
- New tokens are stored in Sanity `apiSettings` document
- Subsequent requests use tokens from Sanity
- Refresh tokens last 1 year and renew themselves when used

## Test Plan
- [x] Build passes (`npm run build`)
- [x] API endpoints return correct responses
- [x] Fallback images display when APIs not configured
- [x] Hover effect shows correct platform icon
- [ ] Test with real LinkedIn API credentials
- [ ] Verify token auto-refresh works

🤖 Generated with [Claude Code](https://claude.ai/code)